### PR TITLE
Mutable Estimators 

### DIFF
--- a/dklearn/core.py
+++ b/dklearn/core.py
@@ -7,7 +7,7 @@ from dask.delayed import Delayed
 from dask.optimize import fuse
 from dask.threaded import get as threaded_get
 from dask.utils import concrete, Dispatch
-from sklearn.base import clone, BaseEstimator
+from sklearn.base import BaseEstimator
 from toolz import merge, identity
 
 
@@ -19,13 +19,6 @@ class DaskBaseEstimator(Base):
     def _optimize(dsk, keys, **kwargs):
         dsk2, deps = fuse(dsk, keys)
         return dsk2
-
-    def get_params(self, deep=True):
-        return self._est.get_params(deep=deep)
-
-    def set_params(self, **params):
-        est = clone(self._est).set_params(**params)
-        return type(self).from_sklearn(est)
 
 
 @partial(normalize_token.register, BaseEstimator)

--- a/dklearn/estimator.py
+++ b/dklearn/estimator.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import, print_function, division
 
+from copy import deepcopy
 from operator import getitem
 
 from sklearn.base import clone, BaseEstimator
-from dask.base import tokenize
+from dask.base import tokenize, Base, normalize_token
 from dask.delayed import Delayed
-from toolz import merge
+from dask.optimize import fuse
+from dask.threaded import get as threaded_get
+from toolz import partial
 
-from .core import DaskBaseEstimator, unpack_arguments, from_sklearn
+from .core import unpack_arguments, from_sklearn
 
 
 def _fit(est, X, y, kwargs):
@@ -37,45 +40,124 @@ def _fit_transform(est, X, y, kwargs):
     return fit, tr
 
 
-class Estimator(DaskBaseEstimator):
-    """A class for wrapping a scikit-learn estimator.
+class ClassProxy(object):
+    def __init__(self, cls):
+        self.cls = cls
 
-    All operations done on this estimator are pure (no mutation), and are done
-    lazily (if applicable). Calling `compute` results in the wrapped estimator.
-    """
+    @property
+    def __name__(self):
+        return 'Dask' + self.cls.__name__
 
-    def __init__(self, est, dask=None, name=None):
-        if dask is None and name is None:
-            name = 'from_sklearn-' + tokenize(est)
-            dask = {name: est}
-        elif dask is None or name is None:
-            raise ValueError("Must provide both dask and name")
-        self.dask = dask
-        self._name = name
-        self._est = est
+    def __call__(self, *args, **kwargs):
+        return Estimator(self.cls(*args, **kwargs))
 
-    @staticmethod
-    def _finalize(res):
-        return res[0]
+
+class Estimator(Base, BaseEstimator):
+    _default_get = staticmethod(threaded_get)
+    _finalize = staticmethod(lambda res: Estimator(res[0]))
+    _optimize = staticmethod(lambda d, k, **kws: fuse(d, k)[0])
+
+    def __init__(self, est, copy=True):
+        if not isinstance(est, BaseEstimator):
+            raise TypeError("Expected instance of `BaseEstimator`, "
+                            "got {0}".format(type(est).__name__))
+        if copy:
+            est = deepcopy(est)
+        self._base = est
+        self._reset()
+
+    def _reset(self, fastpath=False):
+        """Reset the base graph for lazy computations."""
+        self._name = name = 'from_sklearn-' + tokenize(self._base)
+        self.dask = {name: self._base}
 
     def _keys(self):
         return [self._name]
 
-    @classmethod
-    def from_sklearn(cls, est):
-        """Wrap a scikit-learn estimator"""
-        return cls(est)
+    @property
+    def __class__(self):
+        return ClassProxy(type(self._base))
 
     @property
     def _estimator_type(self):
-        return self._est._estimator_type
+        return self._base._estimator_type
+
+    def get_params(self, deep=True):
+        return self._base.get_params(deep=True)
+
+    def set_params(self, **params):
+        self._base.set_params(**params)
+        self._reset()
+        return self
+
+    def __getattr__(self, attr):
+        if hasattr(self._base, attr):
+            return getattr(self._base, attr)
+        else:
+            raise AttributeError("Attribute {0} either missing, or not "
+                                 "computed yet. Try calling `.compute()`, "
+                                 "and check again.".format(attr))
+
+    def __setattr__(self, k, v):
+        if k in ('_name', 'dask', '_base'):
+            object.__setattr__(self, k, v)
+        else:
+            raise AttributeError("Attribute setting not permitted. "
+                                 "Use `set_params` to change parameters")
+
+    def __dir__(self):
+        o = set(dir(type(self)))
+        o.update(self.__dict__)
+        o.update(self._base._get_param_names())
+        o.update(i for i in dir(self._base) if i.endswith('_'))
+        return list(o)
+
+    @classmethod
+    def from_sklearn(cls, est):
+        return cls(est)
+
+    def to_sklearn(self, compute=True):
+        if compute:
+            if len(self.dask) > 1:
+                return Delayed(self._name, [self.dask]).compute()
+            return self._base
+        return Delayed(self._name, [self.dask])
 
     def fit(self, X, y, **kwargs):
+        # Remove all fit (`foo_`) attributes, reset graph
+        self._base = clone(self._base)
+        self._reset()
+        # Construct the fit step
         name = 'fit-' + tokenize(self, X, y, kwargs)
         X, y, dsk = unpack_arguments(X, y)
         dsk.update(self.dask)
         dsk[name] = (_fit, self._name, X, y, kwargs)
-        return Estimator(self._est, dsk, name)
+        self._name = name
+        self.dask = dsk
+        return self
+
+    def _fit_transform(self, X, y, **kwargs):
+        # Remove all fit (`foo_`) attributes, reset graph
+        self._base = clone(self._base)
+        self._reset()
+        # Construct the fit and transform steps
+        token = tokenize(self, X, y, kwargs)
+        fit_tr_name = 'fit-transform-' + token
+        fit_name = 'fit-' + token
+        tr_name = 'tr-' + token
+        X, y, dsk = unpack_arguments(X, y)
+        dsk.update(self.dask)
+        dsk[fit_tr_name] = (_fit_transform, self._name, X, y, kwargs)
+        dsk2 = dsk.copy()
+        dsk[fit_name] = (getitem, fit_tr_name, 0)
+        dsk2[tr_name] = (getitem, fit_tr_name, 1)
+        self._name = fit_name
+        self.dask = dsk
+        return self, Delayed(tr_name, [dsk2])
+
+    def fit_transform(self, X, y, **kwargs):
+        _, Xt = self._fit_transform(X, y, **kwargs)
+        return Xt
 
     def predict(self, X):
         name = 'predict-' + tokenize(self, X)
@@ -95,16 +177,10 @@ class Estimator(DaskBaseEstimator):
         dsk[name] = (_transform, self._name, X)
         return Delayed(name, [dsk, self.dask])
 
-    def _fit_transform(self, X, y, **kwargs):
-        token = tokenize(self, X, y, kwargs)
-        fit_tr_name = 'fit-transform-' + token
-        fit_name = 'fit-' + token
-        tr_name = 'tr-' + token
-        X, y, dsk = unpack_arguments(X, y)
-        dsk[fit_tr_name] = (_fit_transform, self._name, X, y, kwargs)
-        dsk1 = merge({fit_name: (getitem, fit_tr_name, 0)}, dsk, self.dask)
-        dsk2 = merge({tr_name: (getitem, fit_tr_name, 1)}, dsk, self.dask)
-        return Estimator(self._est, dsk1, fit_name), Delayed(tr_name, [dsk2])
+
+@partial(normalize_token.register, Estimator)
+def normalize_dask_estimators(est):
+    return type(est).__name__, est._name
 
 
 from_sklearn.dispatch.register(BaseEstimator, Estimator.from_sklearn)


### PR DESCRIPTION
This is an attempt to provide estimators that mutate instead of being immutable (like most dask estimators). After writing this, I no longer think this is a good idea, it makes things very tricky to reason about. This PR is just for discussion.

Currently the following works:

```python
import numpy as np
from dask import compute
from sklearn import linear_model, decomposition, datasets, pipeline
from sklearn.base import BaseEstimator
from dklearn.pipeline import Pipeline
from dklearn.grid_search import GridSearchCV

logistic = linear_model.LogisticRegression()
pca = decomposition.PCA()

# Create a dask backed pipeline. All operations on this happen lazily.
pipe = Pipeline(steps=[('pca', pca), ('logistic', logistic)])

# dask estimators are also sklearn estimators
assert isinstance(pipe, BaseEstimator)
# This means that `clone`, etc... work just fine

digits = datasets.load_digits()
X_digits = digits.data
y_digits = digits.target

# All of these run lazily, but match the sklearn api
pipe.fit(X_digits, y_digits)
# just for the demo, don't really test on the training set :)
predicted = pipe.predict(X_digits)
score = pipe.score(X_digits, y_digits)

# Computing many things at once
pipe2, predicted, score = compute(pipe, predicted, score)

# Computed estimators are still dask objects
assert isinstance(pipe2, Pipeline)
# But they're not the same as the pre-compute object (no mutation from
# computation)
assert pipe is not pipe2

# The `to_sklearn` method converts back to sklearn objects
pipe3 = pipe.to_sklearn()
assert isinstance(pipe3, pipeline.Pipeline)
assert not isinstance(pipe3, Pipeline)  # not a dask pipeline


# GridSearchCV and RandomizedSearchCV are also implemented. These don't
# currently happen lazily, due to the need for `refit`.
n_components = [20, 40, 64]
Cs = np.logspace(-4, 4, 3)
grid = dict(pca__n_components=n_components,
            logistic__C=Cs)

search = GridSearchCV(pipe, grid)
search.fit(X_digits, y_digits)
assert isinstance(search.best_estimator_, Pipeline)
```